### PR TITLE
🔒 Add sandbox attribute to iframes for security

### DIFF
--- a/src/components/ModalFrame.vue
+++ b/src/components/ModalFrame.vue
@@ -11,6 +11,7 @@
           frameborder="0"
           marginheight="0"
           marginwidth="0"
+          sandbox="allow-scripts allow-same-origin allow-forms"
           >Loading…</iframe
         >
       </div>

--- a/src/components/Previews.vue
+++ b/src/components/Previews.vue
@@ -97,6 +97,7 @@
                   class="webembed"
                   v-if="showExcerpt && isEmbeddable(project)"
                   :src="getEmbed(project)"
+                  sandbox="allow-scripts allow-same-origin"
                 ></iframe>
 
                 <div
@@ -152,6 +153,7 @@
                     class="webembed"
                     id="webembedframe"
                     :src="getEmbed(project)"
+                    sandbox="allow-scripts allow-same-origin"
                   ></iframe>
                 </div>
                 <button


### PR DESCRIPTION
🎯 **What:** Added the `sandbox` attribute to all `<iframe>` elements in `Previews.vue` and `ModalFrame.vue`.

⚠️ **Risk:** Without a sandbox, embedded content could potentially execute malicious scripts in the context of the parent page or perform clickjacking attacks.

🛡️ **Solution:** Implemented the `sandbox` attribute with restricted permissions. In `Previews.vue`, used `allow-scripts allow-same-origin`. In `ModalFrame.vue`, added `allow-forms` as well to support embedded Google Forms.

---
*PR created automatically by Jules for task [8313855323161934604](https://jules.google.com/task/8313855323161934604) started by @loleg*