### PR TITLE
Make timer length configurable again

### DIFF
--- a/src/components/Previews.vue
+++ b/src/components/Previews.vue
@@ -383,9 +383,7 @@ export default {
     };
 
     const countDown = () => {
-      const TIMER_LENGTH_MINUTES = 3;
-      // TODO: make configurable again
-      //  parseInt(process.env.VUE_APP_TIMER_LENGTH) || 3;
+      const TIMER_LENGTH_MINUTES = parseInt(import.meta.env.VITE_TIMER_LENGTH) || 3;
       const pc_per_tick =
         TIMER_LENGTH_MINUTES > 0 ? 100 / (60 * TIMER_LENGTH_MINUTES) : 0;
       if (pc_per_tick == 0) return;

--- a/src/components/Previews.vue
+++ b/src/components/Previews.vue
@@ -383,7 +383,7 @@ export default {
     };
 
     const countDown = () => {
-      const TIMER_LENGTH_MINUTES = parseInt(import.meta.env.VITE_TIMER_LENGTH) || 3;
+      const TIMER_LENGTH_MINUTES = parseInt(import.meta.env.VITE_TIMER_LENGTH || 3);
       const pc_per_tick =
         TIMER_LENGTH_MINUTES > 0 ? 100 / (60 * TIMER_LENGTH_MINUTES) : 0;
       if (pc_per_tick == 0) return;


### PR DESCRIPTION
The timer length in presentation mode was hardcoded to 3 minutes. This change makes it configurable via the `VITE_TIMER_LENGTH` environment variable, while maintaining a default of 3 minutes. The solution uses `import.meta.env` and the `VITE_` prefix, consistent with the project's Vite-based configuration.

---
*PR created automatically by Jules for task [3916708532546328289](https://jules.google.com/task/3916708532546328289) started by @loleg*