### PR TITLE
🔒 Fix XSS via iframe src and enhance sandbox security

### DIFF
--- a/src/components/ModalFrame.vue
+++ b/src/components/ModalFrame.vue
@@ -11,6 +11,7 @@
           frameborder="0"
           marginheight="0"
           marginwidth="0"
+          sandbox="allow-scripts allow-same-origin allow-forms"
           >Loading…</iframe
         >
       </div>
@@ -28,6 +29,11 @@ export default {
   },
   components: {
     Modal,
+  },
+  methods: {
+    isValidUrl(url) {
+      return url && (url.startsWith("http://") || url.startsWith("https://"));
+    },
   },
   data() {
     return {
@@ -48,7 +54,7 @@ export default {
       formref = formref + "/viewform?embedded=true";
     }
 
-    this.framesrc = formref;
+    this.framesrc = this.isValidUrl(formref) ? formref : null;
   },
 };
 </script>

--- a/src/components/Previews.vue
+++ b/src/components/Previews.vue
@@ -97,6 +97,7 @@
                   class="webembed"
                   v-if="showExcerpt && isEmbeddable(project)"
                   :src="getEmbed(project)"
+                  sandbox="allow-scripts allow-same-origin allow-forms"
                 ></iframe>
 
                 <div
@@ -152,6 +153,7 @@
                     class="webembed"
                     id="webembedframe"
                     :src="getEmbed(project)"
+                    sandbox="allow-scripts allow-same-origin allow-forms"
                   ></iframe>
                 </div>
                 <button
@@ -290,12 +292,20 @@ export default {
       return project.webpage_url || isWithslides(project);
     };
 
+    const isValidUrl = (url) => {
+      return url && (url.startsWith("http://") || url.startsWith("https://"));
+    };
+
     const getEmbed = (project) => {
-      if (isWithslides(project)) return project.url + "/render";
-      if (!project.webpage_url) return "";
-      return project.webpage_url.endsWith(".pdf")
-        ? project.url + "/render"
-        : project.webpage_url;
+      let url = "";
+      if (isWithslides(project)) {
+        url = project.url + "/render";
+      } else if (project.webpage_url) {
+        url = project.webpage_url.endsWith(".pdf")
+          ? project.url + "/render"
+          : project.webpage_url;
+      }
+      return isValidUrl(url) ? url : "";
     };
 
     const seeEmbed = (project) => {


### PR DESCRIPTION
🎯 **What:** Fixed a Cross-Site Scripting (XSS) vulnerability where untrusted URLs could be used in `iframe` `src` attributes. Also added `sandbox` attributes to all `iframe` tags.
⚠️ **Risk:** An attacker could potentially inject `javascript:` URLs or other malicious schemes into project data, leading to arbitrary code execution in the context of the user's browser.
🛡️ **Solution:** Added a `isValidUrl` helper to ensure only `http://` and `https://` protocols are permitted. Applied this validation to `Previews.vue` and `ModalFrame.vue`. Added `sandbox="allow-scripts allow-same-origin allow-forms"` to all `iframe` elements to provide defense-in-depth while maintaining necessary functionality for project embeds and forms.

---
*PR created automatically by Jules for task [7443788764402903990](https://jules.google.com/task/7443788764402903990) started by @loleg*